### PR TITLE
Fix typo `gen-env` -> `env-gen`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ project.
 ```json
 {
   "scripts": {
-    "dev": "gen-env && react-scripts start"
+    "dev": "env-gen && react-scripts start"
   }
 }
 ```


### PR DESCRIPTION
Fix typo `gen-env` -> `env-gen`.

Not sure how the change in the last line happen. I edited this using GitHub UI.