### PR TITLE
fix: variables with quotes are now supported

### DIFF
--- a/bin/env-gen.sh
+++ b/bin/env-gen.sh
@@ -7,7 +7,13 @@ ENV_JS=${ENV_JS:-env.js}
 
 if [[ -f .env ]]
 then
-    export $(grep -v '^#' .env | xargs)
+    while IFS= read -r line
+    do
+        var="$(echo "$line" | grep -v '^#' | xargs -0)"
+        [ -z "$var" ] && continue
+        IFS='=' read -r key value <<< "$var"
+        export "$key=$value"
+    done < .env
 fi
 
 # get any environment vars set in `env` which are whitelisted variables.


### PR DESCRIPTION
Hello.

I had issues with environment variables that contained quotes. For example:
TIMESTAMP_FORMAT="DD.MM.YYYY HH:mm:ss"
Would be parsed to:
```
{
  "TIMESTAMP_FORMAT": "DD.MM.YYYY"
}
```

This fixes the issue and allows variable values with quotes.